### PR TITLE
refactor(migrations): Switch control flow migration reformat default …

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -19,7 +19,7 @@ import {canRemoveCommonModule, formatTemplate, processNgTemplates, removeImports
  */
 export function migrateTemplate(
     template: string, templateType: string, node: ts.Node, file: AnalyzedFile,
-    format: boolean = false): {migrated: string, errors: MigrateError[]} {
+    format: boolean = true): {migrated: string, errors: MigrateError[]} {
   let errors: MigrateError[] = [];
   let migrated = template;
   if (templateType === 'template') {

--- a/packages/core/schematics/ng-generate/control-flow-migration/schema.json
+++ b/packages/core/schematics/ng-generate/control-flow-migration/schema.json
@@ -14,7 +14,7 @@
       "type": "boolean",
       "description": "Enables reformatting of your templates",
       "x-prompt": "Should the migration reformat your templates?",
-      "default": "false"
+      "default": "true"
     }
   }
 }

--- a/packages/core/src/defer/utils.ts
+++ b/packages/core/src/defer/utils.ts
@@ -141,6 +141,6 @@ export function assertDeferredDependenciesLoaded(tDetails: TDeferBlockDetails) {
  * that a primary template exists. All the other template options are optional.
  */
 export function isTDeferBlockDetails(value: unknown): value is TDeferBlockDetails {
-  return (typeof value === 'object') &&
+  return value !== null && (typeof value === 'object') &&
       (typeof (value as TDeferBlockDetails).primaryTmplIndex === 'number');
 }

--- a/packages/core/src/image_performance_warning.ts
+++ b/packages/core/src/image_performance_warning.ts
@@ -49,7 +49,7 @@ export class ImagePerformanceWarning implements OnDestroy {
       // Angular doesn't have to run change detection whenever any asynchronous tasks are invoked in
       // the scope of this functionality.
       this.ngZone.runOutsideAngular(() => {
-        this.window?.addEventListener('load', waitToScan);
+        this.window?.addEventListener('load', waitToScan, {once: true});
       });
     }
   }

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -190,6 +190,39 @@ describe('DeferFixture', () => {
     expect(el.querySelector('.more')).toBeDefined();
   });
 
+  it('should work with templates that have local refs', async () => {
+    @Component({
+      selector: 'defer-comp',
+      standalone: true,
+      imports: [SecondDeferredComp],
+      template: `
+        <ng-template #template>Hello</ng-template>
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          }
+        </div>
+      `
+    })
+    class DeferComp {
+    }
+
+    TestBed.configureTestingModule({
+      imports: [
+        DeferComp,
+        SecondDeferredComp,
+      ],
+      providers: COMMON_PROVIDERS,
+      deferBlockBehavior: DeferBlockBehavior.Manual,
+    });
+
+    const componentFixture = TestBed.createComponent(DeferComp);
+    const deferBlock = (await componentFixture.getDeferBlocks())[0];
+    const el = componentFixture.nativeElement as HTMLElement;
+    await deferBlock.render(DeferBlockState.Complete);
+    expect(el.querySelector('.more')).toBeDefined();
+  });
+
   it('should render a placeholder defer state', async () => {
     @Component({
       selector: 'defer-comp',

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -10,7 +10,7 @@ import {Compiler, Component, CUSTOM_ELEMENTS_SCHEMA, Directive, forwardRef, getM
 import {ɵɵdefineInjectable} from '@angular/core/src/di/interface/defs';
 import {NgModuleType} from '@angular/core/src/render3';
 import {getNgModuleDef} from '@angular/core/src/render3/definition';
-import {ComponentFixture, inject} from '@angular/core/testing';
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 
 import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
 import {clearModulesForTest, setAllowDuplicateNgModuleIdsForTest} from '../../src/linker/ng_module_registration';
@@ -101,13 +101,9 @@ describe('NgModule', () => {
       componentDef.TView = null;
     }
 
-    const ngModule = createModule(moduleType, injector);
+    createModule(moduleType, injector);
 
-    const cf = ngModule.componentFactoryResolver.resolveComponentFactory(compType)!;
-
-    const comp = cf.create(Injector.NULL);
-
-    return new ComponentFixture(comp, null, null, false);
+    return TestBed.createComponent(compType);
   }
 
   describe('errors', () => {


### PR DESCRIPTION
…to true (#52971)

This switches the default behavior of the control flow migration template reformatting from opt-in to opt-out.

PR Close #52971

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
